### PR TITLE
add global before and after each handler and prettier

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.prettierrc

--- a/404.html
+++ b/404.html
@@ -68,7 +68,7 @@
         }
 
         // Import the tinyrouter module.
-        import router from './tinyrouter.js/tinyrouter.js';
+        import router from '/tinyrouter.js/tinyrouter.js';
 
         // Create router instance
         const r = router.new({

--- a/404.html
+++ b/404.html
@@ -68,7 +68,7 @@
         }
 
         // Import the tinyrouter module.
-        import router from '/tinyrouter.js/tinyrouter.js';
+        import router from './tinyrouter.js/tinyrouter.js';
 
         // Create router instance
         const r = router.new({
@@ -85,6 +85,22 @@
             log('users-on', ctx.location, 'id =', ctx.params.id)
         });
 
+        r.beforeEach(()=>{
+            console.log("before each 1")
+        })
+
+        r.beforeEach(()=>{
+            console.log("before each 2")
+        })
+
+        r.afterEach(()=>{
+            console.log("after each 1")
+        })
+
+        r.afterEach(()=>{
+            console.log("after each 2")
+        })
+        
         // Optional before() and after() callbacks.
         r.on('/tinyrouter.js/demo/users/{id}/objects/{type}', {
             // before: (ctx) => log('users-objects-before'),

--- a/README.md
+++ b/README.md
@@ -64,6 +64,26 @@ r.navigate('/users/42', { filter: 'active' }, 'settings');
 
 See the [demo source](https://github.com/knadh/tinyrouter.js/blob/master/404.html) for a full working example.
 
+### Global handlers
+
+You can register global handlers that run for every navigation:
+
+```javascript
+// Runs before every route's before/on/after handlers
+r.beforeEach((ctx) => {
+  console.log('global beforeEach', ctx.path, ctx.location.pathname);
+});
+
+// Runs after every route's before/on/after handlers
+r.afterEach((ctx) => {
+  console.log('global afterEach', ctx.path, ctx.location.pathname);
+});
+// Order: global beforeEach -> group before -> route before -> on -> route after -> group after -> global afterEach
+
+```
+
+Multiple `beforeEach` and `afterEach` handlers may be registered; they run in the order they were added.
+
 ### Link binding
 
 Simply add the `data-route` attribute to links for automatic on-click naviation.
@@ -83,5 +103,7 @@ Simply add the `data-route` attribute to links for automatic on-click naviation.
 | `r.ready()` | Initializes the router |
 | `r.navigate(path, query, hash, pushState)` | Navigates to a new route |
 | `r.bind(parent)` | Binds navigate() onclick of all elements in the parent tagged with `data-route` |
+| `r.beforeEach(handler)` | Registers a global handler that runs before every navigation |
+| `r.afterEach(handler)` | Registers a global handler that runs after every navigation |
 
 Licensed under the MIT License.

--- a/tinyrouter.js
+++ b/tinyrouter.js
@@ -18,6 +18,20 @@ class Router {
     constructor(options) {
         this.routes = [];
         this.options = { ..._default_options, ...options };
+        this.beforeEachHandlers = [];
+        this.afterEachHandlers = [];
+    }
+
+    // Register a beforeEach handler that runs before every navigation.
+    beforeEach(handler) {
+        this.beforeEachHandlers.push(handler);
+        return this;
+    }
+
+    // Register an afterEach handler that runs after every navigation.
+    afterEach(handler) {
+        this.afterEachHandlers.push(handler);
+        return this;
     }
 
     // Register a new route with optional handlers.
@@ -139,12 +153,20 @@ class Router {
         })
     }
 
-    // Execute handlers in sequence: before -> on -> after.
+    // Execute handlers in sequence: beforeEach -> before -> on -> after -> afterEach.
     _execHandlers(handlers, ctx) {
         const chain = [];
+        
+        // Add global beforeEach handlers
+        chain.push(...this.beforeEachHandlers);
+        
+        // Add route-specific handlers
         handlers.before && chain.push(...[handlers.before].flat());
         handlers.on && chain.push(handlers.on);
         handlers.after && chain.push(...[handlers.after].flat());
+        
+        // Add global afterEach handlers
+        chain.push(...this.afterEachHandlers);
 
         chain.forEach(fn => fn && fn(ctx));
     }


### PR DESCRIPTION
This PR adds `beforeEach` and `afterEach` handlers. Multiple functions could be added.


Also added prettier file , when I cloned vscode was automatically replacing single quotes to doublequote :(

